### PR TITLE
Cast Struct -> Hash, when ResourceRecordSetWrapper#eql? and #update

### DIFF
--- a/lib/roadworker/route53-wrapper.rb
+++ b/lib/roadworker/route53-wrapper.rb
@@ -217,6 +217,7 @@ module Roadworker
           actual = self.public_send(attribute)
           actual = actual.sort_by {|i| i.to_s } if actual.kind_of?(Array)
           actual = nil if actual.kind_of?(Array) && actual.empty?
+          actual = actual.to_h if actual.kind_of?(Struct)
 
           if !expected and !actual
             true
@@ -265,6 +266,7 @@ module Roadworker
           actual = self.send(attribute)
           actual = actual.sort_by {|i| i.to_s } if actual.kind_of?(Array)
           actual = nil if actual.kind_of?(Array) && actual.empty?
+          actual = actual.to_h if actual.kind_of?(Struct)
 
           # XXX: Fix for diff
           if attribute == :health_check and actual


### PR DESCRIPTION
Hi @winebarrel . 

When I run following command.

```sh
$ bundle exec roadwork -e -o Routefile && bundle exec roadwork -a -f Routefile --dry-run
Export Route53 to `Routefile`
Apply `Routefile` to Route53 (dry-run)
Update ResourceRecordSet: xxx.xxxxx.jp. A (Asia) (dry-run)
  geo_location:
     (dry-run)
```

---

For example, `geo_location`

- `actual` return [Aws::Route53::Types::GeoLocation](http://docs.aws.amazon.com/sdkforruby/api/Aws/Route53/Types/GeoLocation.html)
- `expected` is Hash