### PR TITLE
When `apply` same record (with geo_location), STDOUT should be ''

### DIFF
--- a/lib/roadworker/route53-wrapper.rb
+++ b/lib/roadworker/route53-wrapper.rb
@@ -217,6 +217,7 @@ module Roadworker
           actual = self.public_send(attribute)
           actual = actual.sort_by {|i| i.to_s } if actual.kind_of?(Array)
           actual = nil if actual.kind_of?(Array) && actual.empty?
+          actual = actual.to_h if actual.kind_of?(Aws::Route53::Types::GeoLocation)
 
           if !expected and !actual
             true
@@ -265,6 +266,7 @@ module Roadworker
           actual = self.send(attribute)
           actual = actual.sort_by {|i| i.to_s } if actual.kind_of?(Array)
           actual = nil if actual.kind_of?(Array) && actual.empty?
+          actual = actual.to_h if actual.kind_of?(Aws::Route53::Types::GeoLocation)
 
           # XXX: Fix for diff
           if attribute == :health_check and actual

--- a/spec/roadworker_geo_spec.rb
+++ b/spec/roadworker_geo_spec.rb
@@ -76,4 +76,43 @@ EOS
       expect(www2.geo_location).to eq(Aws::Route53::Types::GeoLocation.new(:continent_code=>"EU"))
     }
   end
+
+  context 'when `apply` same record (with geo_location)' do
+    before {
+      routefile do
+<<EOS
+hosted_zone "winebarrel.jp" do
+  rrset "www.winebarrel.jp.", "A" do
+    set_identifier "Asia"
+    ttl 300
+    geo_location :continent_code=>"AS"
+    resource_records(
+      "127.0.0.1"
+    )
+  end
+end
+EOS
+      end
+    }
+
+    it {
+      stdout = StringIO.new
+      routefile(logger: Logger.new(stdout)) do
+<<EOS
+hosted_zone "winebarrel.jp" do
+  rrset "www.winebarrel.jp.", "A" do
+    set_identifier "Asia"
+    ttl 300
+    geo_location :continent_code=>"AS"
+    resource_records(
+      "127.0.0.1"
+    )
+  end
+end
+EOS
+      end
+
+      expect(stdout.string).to eq('')
+    }
+  end
 end

--- a/spec/roadworker_update_spec.rb
+++ b/spec/roadworker_update_spec.rb
@@ -1244,5 +1244,39 @@ EOS
       }
     end
 
+    context 'when `apply` same record' do
+      before {
+        routefile do
+<<EOS
+hosted_zone "winebarrel.jp" do
+  rrset "www.winebarrel.jp.", "A" do
+    ttl 300
+    resource_records(
+      "127.0.0.1"
+    )
+  end
+end
+EOS
+        end
+      }
+
+      it {
+        stdout = StringIO.new
+        routefile(logger: Logger.new(stdout)) do
+<<EOS
+hosted_zone "winebarrel.jp" do
+  rrset "www.winebarrel.jp.", "A" do
+    ttl 300
+    resource_records(
+      "127.0.0.1"
+    )
+  end
+end
+EOS
+        end
+
+        expect(stdout.string).to eq('')
+      }
+    end
   end
 end


### PR DESCRIPTION
If execute `roadwork -a -f Routefile` twice using same Routefile, STDOUT should be ''.
But, when rrset have `geo_location`, STDOUT always out `Update ResourceRecordSet:...`

The cause is because it compares `Hash` and `Aws::Route53::Types::GeoLocation (Struct)`
