### PR TITLE
Deal with zones with the same name associated to different VPCs correctly

### DIFF
--- a/lib/roadworker/client.rb
+++ b/lib/roadworker/client.rb
@@ -63,8 +63,8 @@ module Roadworker
     end
 
     def walk_hosted_zones(dsl)
-      expected = collection_to_hash(dsl.hosted_zones) {|i| [normalize_name(i.name), i.vpcs.empty?] }
-      actual   = collection_to_hash(@route53.hosted_zones) {|i| [normalize_name(i.name), i.vpcs.empty?] }
+      expected = collection_to_hash(dsl.hosted_zones) {|i| [normalize_name(i.name), i.vpcs.map(&:vpc_id)] }
+      actual   = collection_to_hash(@route53.hosted_zones) {|i| [normalize_name(i.name), i.vpcs.map(&:vpc_id)] }
 
       expected.each do |keys, expected_zone|
         name = keys[0]


### PR DESCRIPTION
WHEN two private zones with the same name (say `example.local`) exist
AND these zones are assocaited to the different VPCs (`[vpc1]`, `[vpc2]`)

`[normalize_name(i.name), i.vpcs.empty?]` is the same value `["example.local", true]` and hashes `expected` and `actual` has only one key for `example.local` zone.
This patch changes the latter in the array, and the hash key will be `["example.local", ["vpc1]]` and `["example.local", ["vpc2"]]`, in order to deal with these zones as different ones.

It should be unique, since a private zone can be associated to only one VPC with the same name.

`export` can handle multiple private zones in #33 but `apply` looks not then.