### PR TITLE
Optionally accept hosted zone ID in DSL

### DIFF
--- a/lib/roadworker/dsl-converter.rb
+++ b/lib/roadworker/dsl-converter.rb
@@ -88,12 +88,13 @@ module Roadworker
 
         def output_zone(zone)
           name = zone[:name].inspect
+          id = zone[:id].sub(%r!^/hostedzone/!, '').inspect
           rrsets = zone[:rrsets]
           vpcs = output_vpcs(zone[:vpcs])
           vpcs = "  #{vpcs}\n\n" if vpcs
 
           return(<<-EOS)
-hosted_zone #{name} do
+hosted_zone #{name}#{zone[:vpcs].empty? ? '' : ", #{id}"} do
 #{vpcs
 }#{rrsets.map {|i| output_rrset(i) }.join("\n").chomp}
 end

--- a/lib/roadworker/dsl.rb
+++ b/lib/roadworker/dsl.rb
@@ -50,8 +50,8 @@ module Roadworker
       end
     end
 
-    def hosted_zone(name, &block)
-      @result.hosted_zones << Hostedzone.new(@context, name, [], &block).result
+    def hosted_zone(name, id = nil, &block)
+      @result.hosted_zones << Hostedzone.new(@context, name, id, [], &block).result
     end
 
     class Hostedzone
@@ -59,11 +59,12 @@ module Roadworker
 
       attr_reader :result
 
-      def initialize(context, name, rrsets = [], &block)
+      def initialize(context, name, id, rrsets = [], &block)
         @name = name
         @context = context.merge(:hosted_zone_name => name)
 
         @result = OpenStruct.new({
+          :id => id,
           :name => name,
           :vpcs => [],
           :resource_record_sets => rrsets,

--- a/lib/roadworker/route53-exporter.rb
+++ b/lib/roadworker/route53-exporter.rb
@@ -29,7 +29,7 @@ module Roadworker
       Collection.batch(@options.route53.list_hosted_zones, :hosted_zones) do |zone|
         next unless matched_zone?(zone.name)
         resp = @options.route53.get_hosted_zone(id: zone.id)
-        zone_h = { name: zone.name, vpcs: resp.vp_cs }
+        zone_h = { id: zone.id, name: zone.name, vpcs: resp.vp_cs }
         hosted_zones << zone_h
 
         rrsets = []


### PR DESCRIPTION
When we give the following change

```patch
 hosted_zone "example.com." do
   vpc "us-east-1", "vpc-xxxxxxxx"
+  vpc "us-east-1", "vpc-yyyyyyyy"
 end
```

roadworker tries to recreate the hosted zone.

```
$ roadwork --apply --dry-run --force
Apply `Routefile` to Route53 (dry-run)
Create Hostedzone #<struct Aws::Route53::Types::VPC vpc_region="us-east-1", vpc_id="vpc-xxxxxxxx">: example.com (dry-run)
Associate #<struct Aws::Route53::Types::VPC vpc_region="us-east-1", vpc_id="vpc-yyyyyyyy">: example.com (dry-run)
Delete Hostedzone: example.com. (dry-run)
No change
```

This destructive behavior seems to have been introduced by https://github.com/codenize-tools/roadworker/pull/54 for dealing with the case where we have multiple private hosted zones with the same name.

By applying this patch, it simply associates the VPC to the existing hosted zone.

```
$ roadwork --apply --dry-run
Apply `Routefile` to Route53 (dry-run)
Associate #<struct Aws::Route53::Types::VPC vpc_region="us-east-1", vpc_id="vpc-yyyyyyyy">: example.com. (dry-run)
No change
```

This patch will make DSL optionally accept a hosted zone ID for addressing the issue described in https://github.com/codenize-tools/roadworker/pull/54.

```patch
 hosted_zone "example.com.", "ZXXXXXXXXXXXXX" do
   vpc "us-east-1", "vpc-xxxxxxxx"
 end

 hosted_zone "example.com.", "ZYYYYYYYYYYYYY" do
   vpc "us-east-1", "vpc-yyyyyyyy"
+  rrset "a.example.com.", "CNAME" do
+    resource_records "b.example.com."
+  end
 end
```

```
$ roadwork --apply --dry-run
Apply `Routefile` to Route53 (dry-run)
Create ResourceRecordSet: a.example.com CNAME (dry-run)
No change
```