### PR TITLE
Use aws-sdk V3

### DIFF
--- a/lib/roadworker/route53-ext.rb
+++ b/lib/roadworker/route53-ext.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-route53'
 
 module Aws
   module Route53

--- a/roadworker.gemspec
+++ b/roadworker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   #spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2.2"
+  spec.add_dependency "aws-sdk-route53", "~> 1"
   spec.add_dependency "term-ansicolor"
   spec.add_dependency "net-dns2", "~> 0.8.6"
   spec.add_dependency "uuid"


### PR DESCRIPTION
AWS recommends library maintainers use service specific gems.
cf. https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/

roadworker can't coexists with gems which depend on aws-sdk V3, so I think roadworker should use aws-sdk V3.
