### PR TITLE
Replace net-dns with dnsruby

### DIFF
--- a/roadworker.gemspec
+++ b/roadworker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-route53", "~> 1"
   spec.add_dependency "term-ansicolor"
-  spec.add_dependency "net-dns2", "~> 0.8.6"
+  spec.add_dependency "dnsruby"
   spec.add_dependency "uuid"
   spec.add_dependency "systemu"
   spec.add_dependency "diffy"


### PR DESCRIPTION
Hi!

As reported in #61, the `--test` option of roadworker against ruby2.4 shows the following warnings.

```
$ bundle exec ./bin/roadwork -t
/Users/hoshino/src/github.com/codenize-tools/roadworker/vendor/bundle/ruby/2.4.0/gems/net-dns2-0.8.7/lib/net/dns/rr/types.rb:127: warning: constant ::Fixnum is deprecated
/Users/hoshino/src/github.com/codenize-tools/roadworker/vendor/bundle/ruby/2.4.0/gems/net-dns2-0.8.7/lib/net/dns/rr/classes.rb:35: warning: constant ::Fixnum is deprecated
```

But net-dns gem, which is the cause of the warning, seems to be no longer maintained.
So, this PR replaces the net-dns gem with [dnsruby](https://github.com/alexdalitz/dnsruby).

I confirmed that the all specs passed at my environment.
This PR may also fix #55.