### PR TITLE
CI: Removes an old setting from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-sudo: false
+
 rvm:
 - 2.1.10
 script:


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration