### PR TITLE
Fix `Create ResourceRecordSet` last dot display mismatch.

### DIFF
--- a/lib/roadworker/route53-wrapper.rb
+++ b/lib/roadworker/route53-wrapper.rb
@@ -152,7 +152,7 @@ module Roadworker
 
       def create(name, type, expected_record)
         log(:info, 'Create ResourceRecordSet', :cyan) do
-          log_id = [name, type].join(' ')
+          log_id = [expected_record.name, expected_record.type].join(' ')
           rrset_setid = expected_record.set_identifier
           rrset_setid ? (log_id + " (#{rrset_setid})") : log_id
         end


### PR DESCRIPTION
### Summary

When display `Create ResourceRecordSet`, FQDN last `.` is not appear. 
When display `Delete ResourceRecordSet` or `Update ResourceRecordSet`, `.` is exists.

This PR fix this mismatch. When use Routefile which written right way, show `.` and resolve mismatch. (When last `.` not exist in Routefile, `.` are not displayed.)


### Before

```
Apply `Routefile` to Route53 (dry-run)
Create ResourceRecordSet: example.example.com A (dry-run)
No change
```

```
Apply `Routefile` to Route53 (dry-run)
Delete ResourceRecordSet: example.example.com. A (dry-run)
No change
```

### After

```
Apply `Routefile` to Route53 (dry-run)
Create ResourceRecordSet: example.example.com. A (dry-run)
No change
```

```
Apply `Routefile` to Route53 (dry-run)
Delete ResourceRecordSet: example.example.com. A (dry-run)
No change
```
