### PR TITLE
Submit single change batch per hosted zone on apply

### DIFF
--- a/lib/roadworker.rb
+++ b/lib/roadworker.rb
@@ -17,6 +17,7 @@ require 'roadworker/log'
 require 'roadworker/utils'
 require 'roadworker/template-helper'
 
+require 'roadworker/batch'
 require 'roadworker/client'
 require 'roadworker/collection'
 require 'roadworker/dsl'

--- a/lib/roadworker/batch.rb
+++ b/lib/roadworker/batch.rb
@@ -42,6 +42,14 @@ module Roadworker
       end
     end
 
+    def inspect
+      "#<#{self.class.name}: #{operations.size} operations>"
+    end
+
+    def to_s
+      inspect
+    end
+
     private
 
     def dispatch_batch!(route53, batch, i, total)
@@ -166,6 +174,14 @@ module Roadworker
 
       def diff!(dry_run: false)
         raise NotImplementedError
+      end
+
+      def inspect
+        "#<#{self.class.name} @changes=#{changes.inspect}>"
+      end
+
+      def to_s
+        inspect
       end
 
       private

--- a/lib/roadworker/batch.rb
+++ b/lib/roadworker/batch.rb
@@ -33,6 +33,7 @@ module Roadworker
     end
 
     # @param [Aws::Route53::Client] route53
+    # @return [Boolean] updated
     def request!(route53)
       sorted_operations = operations.sort_by(&:sort_key)
 
@@ -40,6 +41,8 @@ module Roadworker
       batches.each_with_index do |batch, i|
         dispatch_batch!(route53, batch, i, batches.size)
       end
+
+      sorted_operations.any? { |op| !op.changes.empty? }
     end
 
     def inspect

--- a/lib/roadworker/batch.rb
+++ b/lib/roadworker/batch.rb
@@ -1,0 +1,303 @@
+module Roadworker
+  class Batch
+    include Log
+
+    # @param [Roadworker::Route53Wrapper::HostedzoneWrapper] hosted_zone
+    # @param [Roadworker::HealthCheck] health_checks
+    def initialize(hosted_zone, dry_run:, logger:, health_checks:)
+      @hosted_zone = hosted_zone
+      @dry_run = dry_run
+      @logger = logger
+      @health_checks = health_checks
+
+      @operations = []
+    end
+
+    attr_reader :hosted_zone, :health_checks
+    attr_reader :dry_run, :logger
+    attr_reader :operations
+
+    # @param [OpenStruct] rrset Roadworker::DSL::ResourceRecordSet#result
+    def create(rrset)
+      add_operation Create, rrset
+    end
+
+    # @param [OpenStruct] rrset Roadworker::DSL::ResourceRecordSet#result
+    def update(rrset)
+      add_operation Update, rrset
+    end
+
+    # @param [Roadworker::Route53Wrapper::ResourceRecordSetWrapper] rrset
+    def delete(rrset)
+      add_operation Delete, rrset
+    end
+
+    # @param [Aws::Route53::Client] route53
+    def request!(route53)
+      sorted_operations = operations.sort_by(&:sort_key)
+      changes = sorted_operations.flat_map(&:changes)
+      return if changes.empty?
+
+      log(:info, "=== Change batch: #{hosted_zone.name} | #{hosted_zone.id}#{hosted_zone.vpcs.empty? ? '' : ' - private'}", :bold)
+      sorted_operations.each do |operation|
+        operation.diff!()
+      end
+
+      if dry_run
+        log(:info, "---", :bold, dry_run: false)
+      else
+        change = route53.change_resource_record_sets(
+          hosted_zone_id: hosted_zone.id,
+          change_batch: {
+            changes: changes,
+          },
+        )
+        log(:info, "--> Change submitted: #{change.change_info.id}", :bold)
+      end
+      log(:info, "", :bold, dry_run: false)
+    end
+
+    private
+
+    def add_operation(klass, rrset)
+      assert_record_name rrset
+      operations << klass.new(hosted_zone, rrset, health_checks: health_checks, dry_run: dry_run, logger: logger)
+      self
+    end
+
+    def assert_record_name(record)
+      unless record.name.downcase.sub(/\.$/,'').end_with?(hosted_zone.name.sub(/\.$/,''))
+        raise ArgumentError, "#{record.name.inspect} isn't under hosted zone name #{hosted_zone.name.inspect}" 
+      end
+    end
+
+    class Operation
+      include Log
+
+      # @param [Roadworker::Route53Wrapper::HostedzoneWrapper] hosted_zone
+      # @param [Roadworker::DSL::ResourceRecordSet] rrset
+      # @param [Roadworker::HealthCheck] health_checks
+      # @param [Logger] logger
+      def initialize(hosted_zone, rrset, health_checks:, dry_run:, logger:)
+        @hosted_zone = hosted_zone
+        @rrset = rrset
+        @health_checks = health_checks
+        @dry_run = dry_run
+        @logger = logger
+      end
+
+      attr_reader :hosted_zone, :rrset
+      attr_reader :health_checks
+      attr_reader :dry_run, :logger
+
+      def sort_key
+        # Alias target may be created in the same change batch. Let's do operations for non-alias records first.
+        alias_precedence = if rrset.dns_name
+                             1
+                           else
+                             0
+                           end
+        # See Operation#cname_first?
+        cname_precedence = if rrset.type == 'CNAME'
+                             cname_first? ? 0 : 2
+                           else
+                             1
+                           end
+        [rrset.name, alias_precedence, cname_precedence, rrset.type, rrset.set_identifier]
+      end
+
+      # CNAME should always be created/updated later, as CNAME doesn't permit other records
+      # See also Roadworker::Batch::Delete#cname_first?
+      def cname_first?
+        false
+      end
+
+      # @return [Array<Hash>]
+      def changes
+        raise NotImplementedError
+      end
+
+      # @return [Hash]
+      def desired_rrset
+        raise NotImplementedError
+      end
+
+      # @return [Roadworker::Route53Wrapper::ResourceRecordSetWrapper]
+      def present_rrset
+        hosted_zone.find_resource_record_set(rrset.name, rrset.type, rrset.set_identifier) or raise "record not present"
+      end
+
+      def diff!(dry_run: false)
+        raise NotImplementedError
+      end
+
+      private
+
+      # @param [String] dns_name
+      # @param [Hash] options
+      # @return [?]
+      def get_alias_target(dns_name, options)
+        Aws::Route53.dns_name_to_alias_target(dns_name, options, hosted_zone.id, hosted_zone.name)
+      end
+
+      # @param [?] health_check
+      # @return [?]
+      def get_health_check(check)
+        check ? health_checks.find_or_create(check) : nil
+      end
+
+    end
+
+    class Create < Operation
+      # @return [Hash]
+      def desired_rrset
+        return @new_rrset if defined? @new_rrset 
+        @new_rrset = {
+          name: rrset.name,
+          type: rrset.type,
+        }
+
+        Route53Wrapper::RRSET_ATTRS.each do |attribute|
+          value = rrset.send(attribute)
+          next unless value
+
+          case attribute
+          when :dns_name
+            attribute = :alias_target
+            dns_name, dns_name_opts = value
+            value = get_alias_target(dns_name, dns_name_opts)
+          when :health_check
+            attribute = :health_check_id
+            value = get_health_check(value)
+          end
+
+          @new_rrset[attribute] = value
+        end
+
+        @new_rrset
+      end
+
+      def changes
+        [
+          {
+            action: 'CREATE',
+            resource_record_set: desired_rrset.to_h,
+          },
+        ]
+      end
+
+      def diff!
+        log(:info, 'Create ResourceRecordSet', :cyan) do
+          "#{desired_rrset[:name]} #{desired_rrset[:type]}#{ desired_rrset[:set_identifier] && " (#{desired_rrset[:set_identifier]})" }"
+        end
+      end
+    end
+
+    class Delete < Operation
+      # CNAME should always be deleted first, as CNAME doesn't permit other records
+      def cname_first?
+        true
+      end
+
+      def hosted_zone_soa_or_ns?
+        (present_rrset.type == 'SOA' || present_rrset.type == 'NS') && hosted_zone.name == present_rrset.name
+      end
+
+      def changes
+        # Avoid deleting hosted zone SOA/NS
+        if hosted_zone_soa_or_ns?
+          return []
+        end
+
+        [
+          {
+            action: 'DELETE',
+            resource_record_set: present_rrset.to_h,
+          }
+        ]
+      end
+
+      def diff!
+        return if changes.empty?
+        log(:info, 'Delete ResourceRecordSet', :red) do
+          "#{present_rrset.name} #{present_rrset.type}#{ present_rrset.set_identifier && " (#{present_rrset.set_identifier})" }"
+        end
+      end
+    end
+
+
+    class Update < Operation
+      def desired_rrset
+        return @desired_rrset if defined? @desired_rrset
+        @desired_rrset = {name: rrset[:name]}
+
+        Route53Wrapper::RRSET_ATTRS_WITH_TYPE.each do |attribute|
+          value = rrset[attribute]
+          next unless value
+
+          case attribute
+          when :dns_name
+            dns_name, dns_name_opts = value
+            @desired_rrset[:alias_target] = get_alias_target(dns_name, dns_name_opts)
+          when :health_check
+            @desired_rrset[:health_check_id] = get_health_check(value)
+          else
+            @desired_rrset[attribute] = value
+          end
+        end
+
+        @desired_rrset
+      end
+
+      def changes
+        [
+          {
+            action: 'DELETE',
+            resource_record_set: present_rrset.to_h,
+          },
+          {
+            action: 'CREATE',
+            resource_record_set: desired_rrset.to_h,
+          },
+        ]
+      end
+
+      def diff!
+        log(:info, 'Update ResourceRecordSet', :green) do
+          "#{present_rrset.name} #{present_rrset.type}#{ present_rrset.set_identifier && " (#{present_rrset.set_identifier})" }"
+        end
+
+        # Note that desired_rrset is directly for Route 53, and present_record is also from Route 53
+        # Only given +rrset+ is brought from DSL, and dns_name & health_check is only valid in our DSL
+        Route53Wrapper::RRSET_ATTRS_WITH_TYPE.each do |attribute|
+          case attribute
+          when :dns_name
+            present = normalize_attribute_for_diff(attribute, present_rrset[:alias_target] && present_rrset[:alias_target][:dns_name])
+            desired = normalize_attribute_for_diff(attribute, desired_rrset[:alias_target] && desired_rrset[:alias_target][:dns_name])
+          when :health_check
+            present = normalize_attribute_for_diff(attribute, present_rrset[:health_check_id])
+            desired = normalize_attribute_for_diff(attribute, desired_rrset[:health_check_id])
+          else
+            present = normalize_attribute_for_diff(attribute, present_rrset[attribute])
+            desired = normalize_attribute_for_diff(attribute, desired_rrset[attribute])
+          end
+
+          if desired != present
+            color = String.colorize # XXX:
+            log(:info, "  #{attribute}:\n".green + Roadworker::Utils.diff(present, desired, color: color, indent: '    '), false)
+          end
+        end
+      end
+
+      private
+
+      def normalize_attribute_for_diff(attribute, value)
+        if value.is_a?(Array)
+          value = Aws::Route53.sort_rrset_values(attribute, value)
+          value = nil if value.empty?
+        end
+        value
+      end
+    end
+  end
+end

--- a/lib/roadworker/dsl.rb
+++ b/lib/roadworker/dsl.rb
@@ -111,7 +111,7 @@ module Roadworker
       end
 
       def ignore_under(rrset_name)
-        ignore /(\A|\.)#{Regexp.escape(rrset_name.to_s.sub(/\.\z/, ''))}\z/
+        ignore(/(\A|\.)#{Regexp.escape(rrset_name.to_s.sub(/\.\z/, ''))}\z/)
       end
 
       def resource_record_set(rrset_name, type, &block)

--- a/lib/roadworker/dsl.rb
+++ b/lib/roadworker/dsl.rb
@@ -16,6 +16,12 @@ module Roadworker
       def test(dsl, options)
         Tester.test(dsl, options)
       end
+
+      def normalize_dns_name(name)
+        # Normalize name. AWS always returns name with trailing dot, and stores name always lowercase.
+        # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html
+        "#{name.downcase}.".sub(/\.+\z/, '.')
+      end
     end # of class method
 
     attr_reader :result
@@ -60,12 +66,12 @@ module Roadworker
       attr_reader :result
 
       def initialize(context, name, id, rrsets = [], &block)
-        @name = name
-        @context = context.merge(:hosted_zone_name => name)
+        @name = DSL.normalize_dns_name(name)
+        @context = context.merge(:hosted_zone_name => @name)
 
         @result = OpenStruct.new({
           :id => id,
-          :name => name,
+          :name => @name,
           :vpcs => [],
           :resource_record_sets => rrsets,
           :rrsets => rrsets,
@@ -123,6 +129,9 @@ module Roadworker
         attr_reader :result
 
         def initialize(context, name, type, &block)
+          name = DSL.normalize_dns_name(name)
+          type = type.upcase
+
           @context = context.merge(
             :rrset_name => name,
             :rrset_type => type

--- a/lib/roadworker/log.rb
+++ b/lib/roadworker/log.rb
@@ -1,12 +1,12 @@
 module Roadworker
   module Log
 
-    def log(level, message, color, log_id = nil)
+    def log(level, message, color, log_id = nil, dry_run: @dry_run || (@options && @options.dry_run), logger: @logger || @options.logger)
       log_id = yield if block_given?
       message = "#{message}: #{log_id}" if log_id
-      message << ' (dry-run)' if @options.dry_run
+      message << ' (dry-run)' if dry_run
       message = message.send(color) if color
-      @options.logger.send(level, message)
+      logger.send(level, message)
     end
 
   end # Log

--- a/lib/roadworker/route53-ext.rb
+++ b/lib/roadworker/route53-ext.rb
@@ -160,6 +160,21 @@ module Aws
         end
       end
 
+      def sort_rrset_values(attribute, values)
+        sort_lambda =
+          case attribute
+          when :resource_records
+            # After aws-sdk-core v3.44.1, Aws::Route53::Types::ResourceRecord#to_s returns filtered string
+            # like "{:value=>\"[FILTERED]\"}" (cf. https://github.com/aws/aws-sdk-ruby/pull/1941).
+            # To keep backward compatibility, sort by the value of resource record explicitly.
+            lambda { |i| i[:value] }
+          else
+            lambda { |i| i.to_s }
+          end
+
+        values.sort_by(&sort_lambda)
+      end
+
       private
 
       def elb_dns_name_to_alias_target(name, region, options)

--- a/lib/roadworker/utils.rb
+++ b/lib/roadworker/utils.rb
@@ -4,12 +4,16 @@ module Roadworker
       def matched_zone?(name)
         result = true
 
+        # XXX: normalization should be happen on DSL as much as possible, but patterns expect no trailing dot
+        # and to keep backward compatibility, removing then dot when checking patterns.
+        name_for_patterns = name.sub(/\.\z/, '')
+
         if @options.exclude_zone
-          result &&= name !~ @options.exclude_zone
+          result &&= name_for_patterns !~ @options.exclude_zone
         end
 
         if @options.target_zone
-          result &&= name =~ @options.target_zone
+          result &&= name_for_patterns =~ @options.target_zone
         end
 
         result


### PR DESCRIPTION
Current roadworker issues 1 ChangeResourceRecordSets API (change batch) per 1 ResourceRecordSet. This doesn't allow:

- Rollback of entire change when there's an error

  - This is the nature and benefit of the API!  https://docs.aws.amazon.com/en_pv/Route53/latest/APIReference/API_ChangeResourceRecordSets.html

- Atomic transision between CNAME and other RR types, or setting/removing set_identifier 

  - CNAME doesn't allow any RR of other types exist on the same name. To allow transision of some DNS name between CNAME and other RR type atomically, we have to issue DELETE/UPDATE changes in a single change batch.  Previously it wasn't implemented correctly because every changes were submitted in an individual batch.

By making changes in a single change batch, these will be resolved. Also, this gives better performance and lower risk of hitting on rate limits.