### PR TITLE
Delete hosted zone and its records correctly

### DIFF
--- a/lib/roadworker/route53-wrapper.rb
+++ b/lib/roadworker/route53-wrapper.rb
@@ -99,9 +99,12 @@ module Roadworker
         if @options.force
           log(:info, 'Delete Hostedzone', :red, @hosted_zone.name)
 
+          change_batch = Batch.new(self, health_checks: @options.health_checks, logger: @options.logger, dry_run: @options.dry_run)
           self.rrsets.each do |record|
-            record.delete
+            change_batch.delete(record)
           end
+
+          change_batch.request!(@options.route53)
 
           unless @options.dry_run
             @options.route53.delete_hosted_zone(id: @hosted_zone.id)


### PR DESCRIPTION
When I tried to delete hosted zone, I got the following error.

```
$ roadwork -a --dry-run --target '^foo.bar$' --force
Apply `Routefile` to Route53 (dry-run)
Delete Hostedzone: foo.bar. (dry-run)
[ERROR] NoMethodError: undefined method `delete' for #<Aws::Route53::Types::ResourceRecordSet:0x00007ff81a9a3278>
```

ResourceRecordSetWrapper#delete was removed in https://github.com/codenize-tools/roadworker/commit/a3876f69ef79ec13c7d999351eaf33b8af2d6b43#diff-f8d164d49d5178a7c052045f1e269148.

So I changed to submit a batch request to delete records associated with
the target hosted zone as well.

@sorah Could you review?