### PR TITLE
Fix priority between CNAME change and ALIAS change 

### DIFF
--- a/lib/roadworker/batch.rb
+++ b/lib/roadworker/batch.rb
@@ -128,19 +128,19 @@ module Roadworker
       attr_reader :dry_run, :logger
 
       def sort_key
-        # Alias target may be created in the same change batch. Let's do operations for non-alias records first.
-        alias_precedence = if rrset.dns_name
-                             1
-                           else
-                             0
-                           end
         # See Operation#cname_first?
         cname_precedence = if rrset.type == 'CNAME'
                              cname_first? ? 0 : 2
                            else
                              1
                            end
-        [rrset.name, alias_precedence, cname_precedence, rrset.type, rrset.set_identifier]
+        # Alias target may be created in the same change batch. Let's do operations for non-alias records first.
+        alias_precedence = if rrset.dns_name
+                             1
+                           else
+                             0
+                           end
+        [rrset.name, cname_precedence, alias_precedence, rrset.type, rrset.set_identifier]
       end
 
       # CNAME should always be created/updated later, as CNAME doesn't permit other records

--- a/spec/roadworker_batch_spec.rb
+++ b/spec/roadworker_batch_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe Roadworker::Batch, skip_route53_setup: true do
+  let(:hosted_zone) { double(Roadworker::Route53Wrapper::HostedzoneWrapper, name: 'winebarrel.jp.', id: nil) }
+  let(:batch) do
+    described_class.new(hosted_zone, dry_run: true, logger: double(Logger), health_checks: double(Roadworker::HealthCheck))
+  end
+
+
+  describe '#sort_key' do
+    it 'prioritizes CNAME deletion over A creation' do
+      batch.create(OpenStruct.new(name: 'winebarrel.jp.', type: 'A'))
+      batch.delete(OpenStruct.new(name: 'winebarrel.jp.', type: 'CNAME'))
+      allow(hosted_zone).to receive(:find_resource_record_set).with('winebarrel.jp.', 'CNAME', nil).and_return(
+        Roadworker::Route53Wrapper::ResourceRecordSetWrapper.new(
+          Aws::Route53::Types::ResourceRecordSet.new(
+            type: 'CNAME',
+            name: 'winebarrel.jp.',
+          ),
+          hosted_zone,
+          {},
+        )
+      )
+      sorted_operations = batch.operations.sort_by(&:sort_key)
+      expect(sorted_operations.flat_map(&:changes)).to match([
+        {action: 'DELETE', resource_record_set: hash_including(type: 'CNAME')},
+        {action: 'CREATE', resource_record_set: hash_including(type: 'A')},
+      ])
+    end
+
+    it 'prioritizes CNAME deletion over ALIAS creation' do
+      batch.create(OpenStruct.new(name: 'winebarrel.jp.', type: 'A', dns_name: 'roadworker.cloudfront.net.'))
+      batch.delete(OpenStruct.new(name: 'winebarrel.jp.', type: 'CNAME'))
+      allow(hosted_zone).to receive(:find_resource_record_set).with('winebarrel.jp.', 'CNAME', nil).and_return(
+        Roadworker::Route53Wrapper::ResourceRecordSetWrapper.new(
+          Aws::Route53::Types::ResourceRecordSet.new(
+            type: 'CNAME',
+            name: 'winebarrel.jp.',
+          ),
+          hosted_zone,
+          {},
+        )
+      )
+      sorted_operations = batch.operations.sort_by(&:sort_key)
+      expect(sorted_operations.flat_map(&:changes)).to match([
+        {action: 'DELETE', resource_record_set: hash_including(type: 'CNAME')},
+        {action: 'CREATE', resource_record_set: hash_including(type: 'A')},
+      ])
+    end
+
+    it 'prioritizes A deletion over CNAME creation' do
+      batch.create(OpenStruct.new(name: 'winebarrel.jp.', type: 'CNAME'))
+      batch.delete(OpenStruct.new(name: 'winebarrel.jp.', type: 'A'))
+      allow(hosted_zone).to receive(:find_resource_record_set).with('winebarrel.jp.', 'A', nil).and_return(
+        Roadworker::Route53Wrapper::ResourceRecordSetWrapper.new(
+          Aws::Route53::Types::ResourceRecordSet.new(
+            type: 'A',
+            name: 'winebarrel.jp.',
+          ),
+          hosted_zone,
+          {},
+        )
+      )
+      sorted_operations = batch.operations.sort_by(&:sort_key)
+      expect(sorted_operations.flat_map(&:changes)).to match([
+        {action: 'DELETE', resource_record_set: hash_including(type: 'A')},
+        {action: 'CREATE', resource_record_set: hash_including(type: 'CNAME')},
+      ])
+    end
+  end
+end

--- a/spec/roadworker_batch_spec.rb
+++ b/spec/roadworker_batch_spec.rb
@@ -67,5 +67,25 @@ RSpec.describe Roadworker::Batch, skip_route53_setup: true do
         {action: 'CREATE', resource_record_set: hash_including(type: 'CNAME')},
       ])
     end
+
+    it 'prioritizes ALIAS deletion over CNAME creation' do
+      batch.create(OpenStruct.new(name: 'winebarrel.jp.', type: 'CNAME'))
+      batch.delete(OpenStruct.new(name: 'winebarrel.jp.', type: 'A', dns_name: 'roadworker.cloudfront.net.'))
+      allow(hosted_zone).to receive(:find_resource_record_set).with('winebarrel.jp.', 'A', nil).and_return(
+        Roadworker::Route53Wrapper::ResourceRecordSetWrapper.new(
+          Aws::Route53::Types::ResourceRecordSet.new(
+            type: 'A',
+            name: 'winebarrel.jp.',
+          ),
+          hosted_zone,
+          {},
+        )
+      )
+      sorted_operations = batch.operations.sort_by(&:sort_key)
+      expect(sorted_operations.flat_map(&:changes)).to match([
+        {action: 'DELETE', resource_record_set: hash_including(type: 'A')},
+        {action: 'CREATE', resource_record_set: hash_including(type: 'CNAME')},
+      ])
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,14 +31,21 @@ Aws.config.update({
 })
 
 RSpec.configure do |config|
-  config.before(:each) {
-    sleep TEST_INTERVAL
-    cleanup_route53
-    @route53 = Aws::Route53::Client.new
+  route53_initialized = false
+
+  config.before(:each) { |example|
+    unless example.metadata[:skip_route53_setup]
+      sleep TEST_INTERVAL
+      cleanup_route53
+      @route53 = Aws::Route53::Client.new
+      route53_initialized = true
+    end
   }
 
   config.after(:all) do
-    routefile(:force => true) { '' }
+    if route53_initialized
+      routefile(:force => true) { '' }
+    end
   end
 end
 


### PR DESCRIPTION
Suppose you have an ALIAS record.

```ruby
hosted_zone 'winebarrel.jp.' do
  rrset 'test.winebarrel.jp.', 'A' do
    dns_name 'roadworker.cloudfront.net.'
  end
end
```

When you'd like to change the ALIAS record to CNAME record, ALIAS deletion must be prioritized over CNAME creation.

```ruby
hosted_zone 'winebarrel.jp.' do
  rrset 'test.winebarrel.jp.', 'CNAME' do
    ttl 300
    resource_records('example.com.')
  end
end
```

```
% roadwork --apply
Apply `Routefile` to Route53
=== Change batch: winebarrel.jp. | /hostedzone/ZXXXXXXXXXXXXX
Create ResourceRecordSet: test.winebarrel.jp. CNAME
Delete ResourceRecordSet: test.winebarrel.jp. A
[ERROR] Aws::Route53::Errors::InvalidChangeBatch: [RRSet of type CNAME with DNS name test.winebarrel.jp. is not permitted as it conflicts with other records with the same DNS name in zone winebarrel.jp.]
```